### PR TITLE
Refactor window management structure

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,9 +14,9 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL
   : RENDERER_DIST;
 
 const windowManager = new WindowManager({
-  viteDevServerUrl: VITE_DEV_SERVER_URL,
-  rendererDist: RENDERER_DIST,
-  vitePublic: process.env.VITE_PUBLIC!,
+  VITE_DEV_SERVER_URL: VITE_DEV_SERVER_URL,
+  RENDERER_DIST: RENDERER_DIST,
+  VITE_PUBLIC: process.env.VITE_PUBLIC!,
   dirname: __dirname,
 });
 

--- a/electron/windows/childWindow.ts
+++ b/electron/windows/childWindow.ts
@@ -1,0 +1,22 @@
+import { BrowserWindow } from 'electron';
+import path from 'node:path';
+
+export interface ChildWindowOptions {
+  VITE_DEV_SERVER_URL?: string;
+  RENDERER_DIST: string;
+  dirname: string;
+}
+
+export function createChildWindow(options: ChildWindowOptions): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 600,
+    height: 400,
+    webPreferences: {
+      preload: path.join(options.dirname, 'preload.mjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  return win;
+}

--- a/electron/windows/mainWindow.ts
+++ b/electron/windows/mainWindow.ts
@@ -1,0 +1,30 @@
+import { BrowserWindow } from 'electron';
+import path from 'node:path';
+
+export interface MainWindowOptions {
+  VITE_DEV_SERVER_URL?: string;
+  RENDERER_DIST: string;
+  VITE_PUBLIC: string;
+  dirname: string;
+}
+
+export function createMainWindow(options: MainWindowOptions): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    icon: path.join(options.VITE_PUBLIC, 'electron-vite.svg'),
+    webPreferences: {
+      preload: path.join(options.dirname, 'preload.mjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (options.VITE_DEV_SERVER_URL) {
+    win.loadURL(options.VITE_DEV_SERVER_URL);
+  } else {
+    win.loadFile(path.join(options.RENDERER_DIST, 'index.html'));
+  }
+
+  return win;
+}

--- a/newwindow.html
+++ b/newwindow.html
@@ -9,6 +9,6 @@
   <body>
     <div id="newWindowRoot"></div>
     <!-- Importa o entry point para a nova janela -->
-    <script type="module" src="/src/pages/newWindow.tsx"></script>
+    <script type="module" src="/src/pages/NewWindow.tsx"></script>
   </body>
 </html>

--- a/src/pages/NewWindow.tsx
+++ b/src/pages/NewWindow.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
-import '../assets/styles/newwindow.css';
+import '../assets/styles/newWindow.css';
 
 const NewWindow: React.FC = () => {
   const [userMessage, setUserMessage] = useState('');


### PR DESCRIPTION
## Summary
- centralize BrowserWindow creation in `electron/windows`
- simplify `WindowManager` to use new helpers
- fix case-sensitive file references

## Testing
- `npm run lint`
- `npm run build` *(fails: Get "https://github.com/electron/electron/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6868320f5bc08333a2dadc0f79323522